### PR TITLE
reduce image size and speed up building image

### DIFF
--- a/erlang/debian/17.4-with-protobuffs/Dockerfile
+++ b/erlang/debian/17.4-with-protobuffs/Dockerfile
@@ -1,38 +1,46 @@
 FROM debian
 MAINTAINER s-kamito@groovenauts.jp
 
+# use Japan mirror
+RUN sed -i -e s@http://http.debian.net/debian@http://ftp.jp.debian.org/debian@ /etc/apt/sources.list
+
 # dependency packages
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends \
-    build-essential make autoconf automake gcc g++ tcl8.5 systemtap systemtap-sdt-dev \
-    libncurses5-dev openssl libssl-dev curl git-core \
-    dh-make devscripts debhelper fakeroot lintian sudo pbuilder piuparts dpatch quilt \
-    python-setuptools protobuf-c-compiler
+RUN apt-get update \
+    && apt-get upgrade -y\
+    && apt-get install -y --no-install-recommends \
+      build-essential make autoconf automake gcc g++ tcl8.5 systemtap systemtap-sdt-dev \
+      libncurses5-dev openssl libssl-dev curl git-core \
+      dh-make devscripts debhelper fakeroot lintian sudo pbuilder piuparts dpatch quilt \
+      python-setuptools protobuf-c-compiler \
+    && apt-get clean
 
 # Protobuffs
-RUN apt-get update
-RUN apt-get -y install openjdk-7-jdk --no-install-recommends
-RUN update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-RUN apt-get -y install maven --no-install-recommends
+RUN apt-get -y install openjdk-7-jdk --no-install-recommends \
+    && update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java \
+    && apt-get -y install maven --no-install-recommends \
+    && apt-get clean
 RUN cd /tmp\
     && wget http://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz \
-    && tar zxvf protobuf-2.5.0.tar.gz \
+    && tar xf protobuf-2.5.0.tar.gz \
     && cd protobuf-2.5.0 \
     && ./configure --prefix=/usr \
-    && make \
-    && make install
+    && make -j `nproc` \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/protobuf-2.5.0.tar.gz /tmp/protobuf-2.5.0
 
 # Erlang install
-RUN mkdir /tmp/erlang
-RUN cd /tmp/erlang \
-    && curl -O http://www.erlang.org/download/otp_src_17.4.tar.gz \
-    && tar zxvf otp_src_17.4.tar.gz \
+RUN mkdir /tmp/erlang \
+    && cd /tmp/erlang \
+    && curl -O http://download.basho.co.jp.cs-ap-e2.ycloud.jp/otp/download/otp_src_17.4.tar.gz \
+    && tar xf otp_src_17.4.tar.gz \
     && cd otp_src_17.4/ \
     && ./configure --enable-m64-build --enable-smp-support --enable-threads \
                    --enable-vm-probes --enable-kernel-poll --with-dynamic-trace=systemtap \
                    --enable-sctp --enable-hipe --without-javac \
-    && make \
-    && make install
+    && make -j `nproc` \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/erlang
 
 CMD ["erl"]


### PR DESCRIPTION
### build time comparison

24 min 8 seconds (master branch) -> 10 min 12 seconds (feature/reduce-size branch)

```
cd erlang/debian/17.4-with-protobuffs/
git checkout master
(date ; echo ''; docker build --no-cache=true -t erlang-17.4-with-protobuffs-master .; echo ''; date) | tee /tmp/master.log
git checkout feature/reduce-size
(date ; echo ''; docker build --no-cache=true -t erlang-17.4-with-protobuffs-reduced .; echo ''; date) | tee /tmp/reduced.log
```


### image size comparison

1.397 GB (master branch) -> 784.5 MB (feature/reduce-size branch)

```
% docker images | grep erlang-17.4-with-protobuffs-
erlang-17.4-with-protobuffs-reduced   latest              b0d29f898af5        49 seconds ago      784.5 MB
erlang-17.4-with-protobuffs-master    latest              5f54ae559bfd        14 minutes ago      1.397 GB
```
